### PR TITLE
feat: 가게 생성/전체 가게 목록 조회/가게 상세 조회 기능 구현 및 사용자 OWNER 제거

### DIFF
--- a/src/main/java/com/delivery/member/application/MemberService.java
+++ b/src/main/java/com/delivery/member/application/MemberService.java
@@ -3,6 +3,7 @@ package com.delivery.member.application;
 import com.delivery.common.security.JwtProvider;
 import com.delivery.member.application.port.PasswordEncoder;
 import com.delivery.member.domain.Member;
+import com.delivery.member.domain.Role;
 import com.delivery.member.exception.MemberErrorCode;
 import com.delivery.member.exception.MemberException;
 
@@ -34,7 +35,7 @@ public class MemberService {
 			command.email(),
 			passwordEncoder.encode(command.password()),
 			command.phone_num(),
-			command.role(),
+			Role.CUSTOMER,
 			command.address()
 		);
 

--- a/src/main/java/com/delivery/member/application/dto/SignUpCommand.java
+++ b/src/main/java/com/delivery/member/application/dto/SignUpCommand.java
@@ -1,12 +1,9 @@
 package com.delivery.member.application.dto;
 
-import com.delivery.member.domain.Role;
-
 public record SignUpCommand(
 	String email,
 	String password,
 	String phone_num,
-	Role role,
 	String address
 ) {
 }

--- a/src/main/java/com/delivery/member/domain/Role.java
+++ b/src/main/java/com/delivery/member/domain/Role.java
@@ -1,7 +1,6 @@
 package com.delivery.member.domain;
 
 public enum Role {
-	OWNER,
 	CUSTOMER,
 	ADMIN
 }

--- a/src/main/java/com/delivery/member/presentation/dto/SignUpRequest.java
+++ b/src/main/java/com/delivery/member/presentation/dto/SignUpRequest.java
@@ -1,7 +1,6 @@
 package com.delivery.member.presentation.dto;
 
 import com.delivery.member.application.dto.SignUpCommand;
-import com.delivery.member.domain.Role;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Size;
@@ -18,10 +17,9 @@ public record SignUpRequest(
 	@NotBlank(message = "전화번호를 입력해주세요.")
 	@Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "전화번호 형식이 옳바르지 않습니다.")
 	String phone_num,
-	Role role,
 	String address
 ) {
 	public SignUpCommand toCommand() {
-		return new SignUpCommand(email, password, phone_num, role, address);
+		return new SignUpCommand(email, password, phone_num, address);
 	}
 }

--- a/src/main/java/com/delivery/store/application/StoreService.java
+++ b/src/main/java/com/delivery/store/application/StoreService.java
@@ -1,0 +1,81 @@
+package com.delivery.store.application;
+
+import java.util.List;
+
+import com.delivery.member.domain.Member;
+import com.delivery.member.exception.MemberErrorCode;
+import com.delivery.member.exception.MemberException;
+import com.delivery.member.repository.MemberRepository;
+import com.delivery.store.application.dto.StoreCreateCommand;
+import com.delivery.store.application.dto.StoreResult;
+import com.delivery.store.application.dto.StoreUpdateCommand;
+import com.delivery.store.domain.Store;
+import com.delivery.store.exception.StoreErrorCode;
+import com.delivery.store.exception.StoreException;
+import com.delivery.store.repository.StoreRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class StoreService {
+
+	private final StoreRepository storeRepository;
+	private final MemberRepository memberRepository;
+
+	@Transactional
+	public void createStore(String email, StoreCreateCommand command) {
+		Member owner = memberRepository.findByEmail(email)
+				.orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+		Store store = new Store(
+				owner,
+				command.name(),
+				command.category(),
+				command.minOrderPrice(),
+				command.deliveryFee(),
+				command.address(),
+				command.phone(),
+				command.openTime(),
+				command.closeTime()
+		);
+
+		storeRepository.save(store);
+	}
+
+	public StoreResult getStore(Long storeId) {
+		Store store = storeRepository.findById(storeId)
+				.orElseThrow(() -> new StoreException(StoreErrorCode.STORE_NOT_FOUND));
+		return StoreResult.from(store);
+	}
+
+	public List<StoreResult> getAllStores() {
+		return storeRepository.findAll()
+				.stream()
+				.map(StoreResult::from)
+				.toList();
+	}
+
+	@Transactional
+	public void updateStore(String email, Long storeId, StoreUpdateCommand command) {
+		Store store = storeRepository.findByIdWithOwner(storeId)
+				.orElseThrow(() -> new StoreException(StoreErrorCode.STORE_NOT_FOUND));
+
+		store.validateOwner(email);
+		store.update(command.name(), command.category(), command.minOrderPrice(), command.deliveryFee(),
+				command.address(), command.phone(), command.openTime(), command.closeTime());
+	}
+
+	@Transactional
+	public void deleteStore(String email, Long storeId) {
+		Store store = storeRepository.findByIdWithOwner(storeId)
+				.orElseThrow(() -> new StoreException(StoreErrorCode.STORE_NOT_FOUND));
+
+		store.validateOwner(email);
+		storeRepository.delete(store);
+	}
+}

--- a/src/main/java/com/delivery/store/application/StoreService.java
+++ b/src/main/java/com/delivery/store/application/StoreService.java
@@ -65,7 +65,9 @@ public class StoreService {
 		Store store = storeRepository.findByIdWithOwner(storeId)
 				.orElseThrow(() -> new StoreException(StoreErrorCode.STORE_NOT_FOUND));
 
-		store.validateOwner(email);
+		if (!store.isOwnedBy(email)) {
+			throw new StoreException(StoreErrorCode.NOT_STORE_OWNER);
+		}
 		store.update(command.name(), command.category(), command.minOrderPrice(), command.deliveryFee(),
 				command.address(), command.phone(), command.openTime(), command.closeTime());
 	}
@@ -75,7 +77,9 @@ public class StoreService {
 		Store store = storeRepository.findByIdWithOwner(storeId)
 				.orElseThrow(() -> new StoreException(StoreErrorCode.STORE_NOT_FOUND));
 
-		store.validateOwner(email);
+		if (!store.isOwnedBy(email)) {
+			throw new StoreException(StoreErrorCode.NOT_STORE_OWNER);
+		}
 		storeRepository.delete(store);
 	}
 }

--- a/src/main/java/com/delivery/store/application/dto/StoreCreateCommand.java
+++ b/src/main/java/com/delivery/store/application/dto/StoreCreateCommand.java
@@ -1,0 +1,15 @@
+package com.delivery.store.application.dto;
+
+import java.time.LocalTime;
+
+public record StoreCreateCommand(
+        String name,
+        String category,
+        int minOrderPrice,
+        int deliveryFee,
+        String address,
+        String phone,
+        LocalTime openTime,
+        LocalTime closeTime
+) {
+}

--- a/src/main/java/com/delivery/store/application/dto/StoreResult.java
+++ b/src/main/java/com/delivery/store/application/dto/StoreResult.java
@@ -1,0 +1,29 @@
+package com.delivery.store.application.dto;
+
+import java.time.LocalTime;
+
+import com.delivery.store.domain.Store;
+
+public record StoreResult(
+        String name,
+        String category,
+        int minOrderPrice,
+        int deliveryFee,
+        String address,
+        String phone,
+        LocalTime openTime,
+        LocalTime closeTime
+) {
+    public static StoreResult from(Store store) {
+        return new StoreResult(
+                store.getName(),
+                store.getCategory(),
+                store.getMinOrderPrice(),
+                store.getDeliveryFee(),
+                store.getAddress(),
+                store.getPhone(),
+                store.getOpenTime(),
+                store.getCloseTime()
+        );
+    }
+}

--- a/src/main/java/com/delivery/store/application/dto/StoreUpdateCommand.java
+++ b/src/main/java/com/delivery/store/application/dto/StoreUpdateCommand.java
@@ -1,0 +1,15 @@
+package com.delivery.store.application.dto;
+
+import java.time.LocalTime;
+
+public record StoreUpdateCommand(
+        String name,
+        String category,
+        int minOrderPrice,
+        int deliveryFee,
+        String address,
+        String phone,
+        LocalTime openTime,
+        LocalTime closeTime
+) {
+}

--- a/src/main/java/com/delivery/store/domain/Store.java
+++ b/src/main/java/com/delivery/store/domain/Store.java
@@ -1,0 +1,91 @@
+package com.delivery.store.domain;
+
+import java.time.LocalTime;
+
+import com.delivery.member.domain.Member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "stores")
+public class Store {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "store_id", nullable = false, updatable = false)
+	private Long store_id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member owner;
+
+	@Column(name = "name", nullable = false, length = 100)
+	private String name;
+
+	@Column(name = "category", nullable = false, length = 50)
+	private String category;
+
+	@Column(name = "min_order_price", nullable = false)
+	private int minOrderPrice;
+
+	@Column(name = "delivery_fee", nullable = false)
+	private int deliveryFee;
+
+	@Column(name = "address", nullable = false)
+	private String address;
+
+	@Column(name = "phone", nullable = false, length = 13)
+	private String phone;
+
+	@Column(name = "open_time", nullable = false)
+	private LocalTime openTime;
+
+	@Column(name = "close_time", nullable = false)
+	private LocalTime closeTime;
+
+	public Store(Member owner, String name, String category, int minOrderPrice, int deliveryFee,
+			String address, String phone, LocalTime openTime, LocalTime closeTime) {
+		this.owner = owner;
+		this.name = name;
+		this.category = category;
+		this.minOrderPrice = minOrderPrice;
+		this.deliveryFee = deliveryFee;
+		this.address = address;
+		this.phone = phone;
+		this.openTime = openTime;
+		this.closeTime = closeTime;
+	}
+
+	public void validateOwner(String email) {
+		if (!this.owner.getEmail().equals(email)) {
+			throw new com.delivery.store.exception.StoreException(
+				com.delivery.store.exception.StoreErrorCode.NOT_STORE_OWNER
+			);
+		}
+	}
+
+	public void update(String name, String category, int minOrderPrice, int deliveryFee,
+			String address, String phone, LocalTime openTime, LocalTime closeTime) {
+		this.name = name;
+		this.category = category;
+		this.minOrderPrice = minOrderPrice;
+		this.deliveryFee = deliveryFee;
+		this.address = address;
+		this.phone = phone;
+		this.openTime = openTime;
+		this.closeTime = closeTime;
+	}
+}

--- a/src/main/java/com/delivery/store/domain/Store.java
+++ b/src/main/java/com/delivery/store/domain/Store.java
@@ -69,12 +69,8 @@ public class Store {
 		this.closeTime = closeTime;
 	}
 
-	public void validateOwner(String email) {
-		if (!this.owner.getEmail().equals(email)) {
-			throw new com.delivery.store.exception.StoreException(
-				com.delivery.store.exception.StoreErrorCode.NOT_STORE_OWNER
-			);
-		}
+	public boolean isOwnedBy(String email) {
+		return this.owner.getEmail().equals(email);
 	}
 
 	public void update(String name, String category, int minOrderPrice, int deliveryFee,

--- a/src/main/java/com/delivery/store/exception/StoreErrorCode.java
+++ b/src/main/java/com/delivery/store/exception/StoreErrorCode.java
@@ -1,0 +1,15 @@
+package com.delivery.store.exception;
+
+import com.delivery.common.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum StoreErrorCode implements ErrorCode {
+	STORE_NOT_FOUND("존재하지 않는 가게입니다."),
+	NOT_STORE_OWNER("가게 사장님만 접근할 수 있습니다.");
+
+	private final String message;
+}

--- a/src/main/java/com/delivery/store/exception/StoreException.java
+++ b/src/main/java/com/delivery/store/exception/StoreException.java
@@ -1,0 +1,16 @@
+package com.delivery.store.exception;
+
+import com.delivery.common.exception.CustomException;
+
+public class StoreException extends CustomException {
+	private final StoreErrorCode errorCode;
+
+	public StoreException(StoreErrorCode errorCode) {
+		super(errorCode);
+		this.errorCode = errorCode;
+	}
+
+	public StoreErrorCode getStoreErrorCode() {
+		return errorCode;
+	}
+}

--- a/src/main/java/com/delivery/store/presentation/StoreController.java
+++ b/src/main/java/com/delivery/store/presentation/StoreController.java
@@ -1,0 +1,75 @@
+package com.delivery.store.presentation;
+
+import java.util.List;
+
+import com.delivery.common.response.ApiResponse;
+import com.delivery.store.application.StoreService;
+import com.delivery.store.presentation.dto.StoreCreateRequest;
+import com.delivery.store.presentation.dto.StoreResponse;
+import com.delivery.store.presentation.dto.StoreUpdateRequest;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/stores")
+@RequiredArgsConstructor
+public class StoreController {
+
+	private final StoreService storeService;
+
+	@PostMapping
+	public ResponseEntity<ApiResponse<Void>> createStore(
+			@AuthenticationPrincipal UserDetails userDetails,
+			@Valid @RequestBody StoreCreateRequest request
+	) {
+		storeService.createStore(userDetails.getUsername(), request.toCommand());
+		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success());
+	}
+
+	@GetMapping("/{storeId}")
+	public ResponseEntity<ApiResponse<StoreResponse>> getStore(@PathVariable Long storeId) {
+		return ResponseEntity.ok(ApiResponse.success(StoreResponse.from(storeService.getStore(storeId))));
+	}
+
+	@GetMapping
+	public ResponseEntity<ApiResponse<List<StoreResponse>>> getAllStores() {
+		List<StoreResponse> stores = storeService.getAllStores()
+				.stream()
+				.map(StoreResponse::from)
+				.toList();
+		return ResponseEntity.ok(ApiResponse.success(stores));
+	}
+
+	@PatchMapping("/{storeId}")
+	public ResponseEntity<ApiResponse<Void>> updateStore(
+			@AuthenticationPrincipal UserDetails userDetails,
+			@PathVariable Long storeId,
+			@Valid @RequestBody StoreUpdateRequest request
+	) {
+		storeService.updateStore(userDetails.getUsername(), storeId, request.toCommand());
+		return ResponseEntity.ok(ApiResponse.success());
+	}
+
+	@DeleteMapping("/{storeId}")
+	public ResponseEntity<ApiResponse<Void>> deleteStore(
+			@AuthenticationPrincipal UserDetails userDetails,
+			@PathVariable Long storeId
+	) {
+		storeService.deleteStore(userDetails.getUsername(), storeId);
+		return ResponseEntity.ok(ApiResponse.success());
+	}
+}

--- a/src/main/java/com/delivery/store/presentation/dto/StoreCreateRequest.java
+++ b/src/main/java/com/delivery/store/presentation/dto/StoreCreateRequest.java
@@ -1,0 +1,24 @@
+package com.delivery.store.presentation.dto;
+
+import java.time.LocalTime;
+
+import com.delivery.store.application.dto.StoreCreateCommand;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record StoreCreateRequest(
+        @NotBlank String name,
+        @NotBlank String category,
+        @Min(0) int minOrderPrice,
+        @Min(0) int deliveryFee,
+        @NotBlank String address,
+        @NotBlank String phone,
+        @NotNull LocalTime openTime,
+        @NotNull LocalTime closeTime
+) {
+    public StoreCreateCommand toCommand() {
+        return new StoreCreateCommand(name, category, minOrderPrice, deliveryFee, address, phone, openTime, closeTime);
+    }
+}

--- a/src/main/java/com/delivery/store/presentation/dto/StoreResponse.java
+++ b/src/main/java/com/delivery/store/presentation/dto/StoreResponse.java
@@ -1,0 +1,29 @@
+package com.delivery.store.presentation.dto;
+
+import java.time.LocalTime;
+
+import com.delivery.store.application.dto.StoreResult;
+
+public record StoreResponse(
+        String name,
+        String category,
+        int minOrderPrice,
+        int deliveryFee,
+        String address,
+        String phone,
+        LocalTime openTime,
+        LocalTime closeTime
+) {
+    public static StoreResponse from(StoreResult result) {
+        return new StoreResponse(
+                result.name(),
+                result.category(),
+                result.minOrderPrice(),
+                result.deliveryFee(),
+                result.address(),
+                result.phone(),
+                result.openTime(),
+                result.closeTime()
+        );
+    }
+}

--- a/src/main/java/com/delivery/store/presentation/dto/StoreUpdateRequest.java
+++ b/src/main/java/com/delivery/store/presentation/dto/StoreUpdateRequest.java
@@ -1,0 +1,24 @@
+package com.delivery.store.presentation.dto;
+
+import java.time.LocalTime;
+
+import com.delivery.store.application.dto.StoreUpdateCommand;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record StoreUpdateRequest(
+        @NotBlank String name,
+        @NotBlank String category,
+        @Min(0) int minOrderPrice,
+        @Min(0) int deliveryFee,
+        @NotBlank String address,
+        @NotBlank String phone,
+        @NotNull LocalTime openTime,
+        @NotNull LocalTime closeTime
+) {
+    public StoreUpdateCommand toCommand() {
+        return new StoreUpdateCommand(name, category, minOrderPrice, deliveryFee, address, phone, openTime, closeTime);
+    }
+}

--- a/src/main/java/com/delivery/store/repository/StoreRepository.java
+++ b/src/main/java/com/delivery/store/repository/StoreRepository.java
@@ -1,0 +1,18 @@
+package com.delivery.store.repository;
+
+import java.util.Optional;
+
+import com.delivery.store.domain.Store;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StoreRepository extends JpaRepository<Store, Long> {
+
+	@Query("SELECT s FROM Store s JOIN FETCH s.owner WHERE s.store_id = :storeId")
+	Optional<Store> findByIdWithOwner(@Param("storeId") Long storeId);
+}
+


### PR DESCRIPTION
## #️⃣연관된 이슈

Close #6 #7 

## 📝작업 내용

 Role 정리 및 Store 도메인 개선

  Role 단순화
  - 회원가입 시 클라이언트가 role을 직접 전달하던 방식 제거 → 가입 시 CUSTOMER로 고정
  - 실제로 사용되지 않던 Role.OWNER 제거

  소유권 검증 로직 개선
  - StoreService에 중복으로 존재하던 if (!store.isOwnedBy()) throw 패턴을 Store.validateOwner()로 도메인 객체 안으로
  이동

  불필요한 owner 조회 제거
  - StoreResult / StoreResponse에서 ownerEmail 필드 제거
  - 조회 API(getStore, getAllStores)에서 JOIN FETCH 제거 → owner를 참조하지 않으므로 N+1 우려 없음
  - 수정/삭제는 validateOwner에서 owner를 참조하므로 JOIN FETCH 유지

## 💬리뷰 요구사항(선택)
  - Store.validateOwner()처럼 예외를 던지는 검증 메서드를 도메인 객체 안에 두는 방식이 적절한지 의견 부탁드립니다.
