### PR TITLE
feat: 장바구니 생성 및 상품 추가 기능 구현

### DIFF
--- a/src/main/java/com/delivery/cart/application/CartService.java
+++ b/src/main/java/com/delivery/cart/application/CartService.java
@@ -1,0 +1,58 @@
+package com.delivery.cart.application;
+
+import com.delivery.cart.application.dto.CartAddCommand;
+import com.delivery.cart.application.dto.CartResult;
+import com.delivery.cart.domain.Cart;
+import com.delivery.cart.exception.CartErrorCode;
+import com.delivery.cart.exception.CartException;
+import com.delivery.cart.repository.CartItemRepository;
+import com.delivery.cart.repository.CartRepository;
+import com.delivery.member.domain.Member;
+import com.delivery.member.repository.MemberRepository;
+import com.delivery.menu.domain.Menu;
+import com.delivery.menu.exception.MenuErrorCode;
+import com.delivery.menu.exception.MenuException;
+import com.delivery.menu.repository.MenuRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CartService {
+
+	private final CartRepository cartRepository;
+	private final CartItemRepository cartItemRepository;
+	private final MemberRepository memberRepository;
+	private final MenuRepository menuRepository;
+
+	@Transactional
+	public CartResult addToCart(String email, CartAddCommand command) {
+		Member member = memberRepository.findByEmail(email).orElseThrow();
+
+		Menu menu = menuRepository.findByIdWithStore(command.menuId())
+			.orElseThrow(() -> new MenuException(MenuErrorCode.MENU_NOT_FOUND));
+
+		if (menu.isSoldOut()) {
+			throw new MenuException(MenuErrorCode.MENU_SOLD_OUT);
+		}
+
+		Cart cart = cartRepository.findByMemberEmailWithItems(email)
+			.orElseGet(() -> cartRepository.save(new Cart(member, menu.getStore())));
+
+		if (cart.hasDifferentStore(menu.getStoreId())) {
+			throw new CartException(CartErrorCode.DIFFERENT_STORE);
+		}
+
+		cart.findItemByMenuId(menu.getMenu_id())
+			.ifPresentOrElse(
+				existing -> existing.addQuantity(command.quantity()),
+				() -> cartItemRepository.save(cart.addItem(menu, command.quantity()))
+			);
+
+		return CartResult.from(cart, cart.getCartItems());
+	}
+}

--- a/src/main/java/com/delivery/cart/application/CartService.java
+++ b/src/main/java/com/delivery/cart/application/CartService.java
@@ -47,11 +47,7 @@ public class CartService {
 			throw new CartException(CartErrorCode.DIFFERENT_STORE);
 		}
 
-		cart.findItemByMenuId(menu.getMenu_id())
-			.ifPresentOrElse(
-				existing -> existing.addQuantity(command.quantity()),
-				() -> cartItemRepository.save(cart.addItem(menu, command.quantity()))
-			);
+		cart.addMenu(menu, command.quantity());
 
 		return CartResult.from(cart, cart.getCartItems());
 	}

--- a/src/main/java/com/delivery/cart/application/dto/CartAddCommand.java
+++ b/src/main/java/com/delivery/cart/application/dto/CartAddCommand.java
@@ -1,0 +1,4 @@
+package com.delivery.cart.application.dto;
+
+public record CartAddCommand(Long menuId, int quantity) {
+}

--- a/src/main/java/com/delivery/cart/application/dto/CartItemResult.java
+++ b/src/main/java/com/delivery/cart/application/dto/CartItemResult.java
@@ -1,0 +1,15 @@
+package com.delivery.cart.application.dto;
+
+import com.delivery.cart.domain.CartItem;
+
+public record CartItemResult(Long menuId, String menuName, int price, int quantity) {
+
+	public static CartItemResult from(CartItem cartItem) {
+		return new CartItemResult(
+			cartItem.getMenu().getMenu_id(),
+			cartItem.getMenu().getName(),
+			cartItem.getMenu().getPrice(),
+			cartItem.getQuantity()
+		);
+	}
+}

--- a/src/main/java/com/delivery/cart/application/dto/CartResult.java
+++ b/src/main/java/com/delivery/cart/application/dto/CartResult.java
@@ -1,0 +1,16 @@
+package com.delivery.cart.application.dto;
+
+import java.util.List;
+
+import com.delivery.cart.domain.Cart;
+import com.delivery.cart.domain.CartItem;
+
+public record CartResult(Long cartId, List<CartItemResult> items) {
+
+	public static CartResult from(Cart cart, List<CartItem> cartItems) {
+		List<CartItemResult> itemResults = cartItems.stream()
+			.map(CartItemResult::from)
+			.toList();
+		return new CartResult(cart.getCart_id(), itemResults);
+	}
+}

--- a/src/main/java/com/delivery/cart/domain/Cart.java
+++ b/src/main/java/com/delivery/cart/domain/Cart.java
@@ -1,0 +1,68 @@
+package com.delivery.cart.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import com.delivery.member.domain.Member;
+import com.delivery.menu.domain.Menu;
+import com.delivery.store.domain.Store;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "carts")
+public class Cart {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "cart_id", nullable = false, updatable = false)
+	private Long cart_id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false, unique = true)
+	private Member member;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "store_id")
+	private Store store;
+
+	@OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<CartItem> cartItems = new ArrayList<>();
+
+	public Cart(Member member, Store store) {
+		this.member = member;
+		this.store = store;
+	}
+
+	public boolean hasDifferentStore(Long storeId) {
+		return !store.getStore_id().equals(storeId);
+	}
+
+	public Optional<CartItem> findItemByMenuId(Long menuId) {
+		return cartItems.stream()
+			.filter(cartItem -> cartItem.getMenu().getMenu_id().equals(menuId))
+			.findFirst();
+	}
+
+	public CartItem addItem(Menu menu, int quantity) {
+		CartItem cartItem = new CartItem(this, menu, quantity);
+		cartItems.add(cartItem);
+		return cartItem;
+	}
+}

--- a/src/main/java/com/delivery/cart/domain/Cart.java
+++ b/src/main/java/com/delivery/cart/domain/Cart.java
@@ -65,4 +65,12 @@ public class Cart {
 		cartItems.add(cartItem);
 		return cartItem;
 	}
+
+	public void addMenu(Menu menu, int quantity) {
+		findItemByMenuId(menu.getMenu_id())
+			.ifPresentOrElse(
+				existing -> existing.addQuantity(quantity),
+				() -> this.cartItems.add(new CartItem(this, menu, quantity))
+			);
+	}
 }

--- a/src/main/java/com/delivery/cart/domain/CartItem.java
+++ b/src/main/java/com/delivery/cart/domain/CartItem.java
@@ -1,0 +1,57 @@
+package com.delivery.cart.domain;
+
+import com.delivery.menu.domain.Menu;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "cart_items")
+public class CartItem {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "cart_item_id", nullable = false, updatable = false)
+	private Long cart_item_id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "cart_id", nullable = false)
+	private Cart cart;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "menu_id", nullable = false)
+	private Menu menu;
+
+	@Column(name = "quantity", nullable = false)
+	private int quantity;
+
+	public CartItem(Cart cart, Menu menu, int quantity) {
+		this.cart = cart;
+		this.menu = menu;
+		this.quantity = quantity;
+	}
+
+	public void addQuantity(int quantity) {
+		this.quantity += quantity;
+	}
+
+	public void increaseQuantity() {
+		this.quantity++;
+	}
+
+	public void decreaseQuantity() {
+		this.quantity--;
+	}
+}

--- a/src/main/java/com/delivery/cart/exception/CartErrorCode.java
+++ b/src/main/java/com/delivery/cart/exception/CartErrorCode.java
@@ -1,0 +1,14 @@
+package com.delivery.cart.exception;
+
+import com.delivery.common.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CartErrorCode implements ErrorCode {
+	DIFFERENT_STORE("같은 가게의 메뉴만 담을 수 있습니다.");
+
+	private final String message;
+}

--- a/src/main/java/com/delivery/cart/exception/CartException.java
+++ b/src/main/java/com/delivery/cart/exception/CartException.java
@@ -1,0 +1,16 @@
+package com.delivery.cart.exception;
+
+import com.delivery.common.exception.CustomException;
+
+public class CartException extends CustomException {
+	private final CartErrorCode errorCode;
+
+	public CartException(CartErrorCode errorCode) {
+		super(errorCode);
+		this.errorCode = errorCode;
+	}
+
+	public CartErrorCode getCartErrorCode() {
+		return errorCode;
+	}
+}

--- a/src/main/java/com/delivery/cart/presentation/CartController.java
+++ b/src/main/java/com/delivery/cart/presentation/CartController.java
@@ -1,0 +1,37 @@
+package com.delivery.cart.presentation;
+
+import com.delivery.cart.application.CartService;
+import com.delivery.cart.presentation.dto.CartAddRequest;
+import com.delivery.cart.presentation.dto.CartResponse;
+import com.delivery.common.response.ApiResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/carts")
+@RequiredArgsConstructor
+public class CartController {
+
+	private final CartService cartService;
+
+	@PostMapping
+	public ResponseEntity<ApiResponse<CartResponse>> addToCart(
+		@AuthenticationPrincipal UserDetails userDetails,
+		@Valid @RequestBody CartAddRequest request
+	) {
+		CartResponse response = CartResponse.from(
+			cartService.addToCart(userDetails.getUsername(), request.toCommand())
+		);
+		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+	}
+}

--- a/src/main/java/com/delivery/cart/presentation/dto/CartAddRequest.java
+++ b/src/main/java/com/delivery/cart/presentation/dto/CartAddRequest.java
@@ -1,0 +1,18 @@
+package com.delivery.cart.presentation.dto;
+
+import com.delivery.cart.application.dto.CartAddCommand;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record CartAddRequest(
+	@NotNull(message = "메뉴 ID는 필수입니다.")
+	Long menuId,
+
+	@Min(value = 1, message = "수량은 1 이상이어야 합니다.")
+	int quantity
+) {
+	public CartAddCommand toCommand() {
+		return new CartAddCommand(menuId, quantity);
+	}
+}

--- a/src/main/java/com/delivery/cart/presentation/dto/CartItemResponse.java
+++ b/src/main/java/com/delivery/cart/presentation/dto/CartItemResponse.java
@@ -1,0 +1,10 @@
+package com.delivery.cart.presentation.dto;
+
+import com.delivery.cart.application.dto.CartItemResult;
+
+public record CartItemResponse(Long menuId, String menuName, int price, int quantity) {
+
+	public static CartItemResponse from(CartItemResult result) {
+		return new CartItemResponse(result.menuId(), result.menuName(), result.price(), result.quantity());
+	}
+}

--- a/src/main/java/com/delivery/cart/presentation/dto/CartResponse.java
+++ b/src/main/java/com/delivery/cart/presentation/dto/CartResponse.java
@@ -1,0 +1,15 @@
+package com.delivery.cart.presentation.dto;
+
+import java.util.List;
+
+import com.delivery.cart.application.dto.CartResult;
+
+public record CartResponse(Long cartId, List<CartItemResponse> items) {
+
+	public static CartResponse from(CartResult result) {
+		return new CartResponse(
+			result.cartId(),
+			result.items().stream().map(CartItemResponse::from).toList()
+		);
+	}
+}

--- a/src/main/java/com/delivery/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/delivery/cart/repository/CartItemRepository.java
@@ -1,0 +1,22 @@
+package com.delivery.cart.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.delivery.cart.domain.Cart;
+import com.delivery.cart.domain.CartItem;
+import com.delivery.menu.domain.Menu;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+
+	@Query("SELECT ci FROM CartItem ci JOIN FETCH ci.menu m JOIN FETCH m.store WHERE ci.cart = :cart")
+	List<CartItem> findByCartWithMenuAndStore(@Param("cart") Cart cart);
+
+	Optional<CartItem> findByCartAndMenu(Cart cart, Menu menu);
+}

--- a/src/main/java/com/delivery/cart/repository/CartRepository.java
+++ b/src/main/java/com/delivery/cart/repository/CartRepository.java
@@ -1,0 +1,24 @@
+package com.delivery.cart.repository;
+
+import java.util.Optional;
+
+import com.delivery.cart.domain.Cart;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CartRepository extends JpaRepository<Cart, Long> {
+
+	@Query("""
+		SELECT DISTINCT c
+		FROM Cart c
+		LEFT JOIN FETCH c.store
+		LEFT JOIN FETCH c.cartItems ci
+		LEFT JOIN FETCH ci.menu
+		WHERE c.member.email = :email
+		""")
+	Optional<Cart> findByMemberEmailWithItems(@Param("email") String email);
+}

--- a/src/main/java/com/delivery/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/delivery/common/exception/GlobalExceptionHandler.java
@@ -7,8 +7,10 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.delivery.cart.exception.CartException;
 import com.delivery.common.response.ApiResponse;
 import com.delivery.member.exception.MemberException;
+import com.delivery.menu.exception.MenuException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -19,6 +21,28 @@ public class GlobalExceptionHandler {
 			case DUPLICATE_EMAIL -> HttpStatus.CONFLICT;
 			case MEMBER_NOT_FOUND -> HttpStatus.NOT_FOUND;
 			case INVALID_PASSWORD, UNAUTHORIZED -> HttpStatus.UNAUTHORIZED;
+		};
+		return ResponseEntity
+			.status(status)
+			.body(ApiResponse.fail(e.getErrorMessage()));
+	}
+
+	@ExceptionHandler(MenuException.class)
+	public ResponseEntity<ApiResponse<?>> handleMenuException(MenuException e) {
+		HttpStatus status = switch (e.getMenuErrorCode()) {
+			case MENU_NOT_FOUND -> HttpStatus.NOT_FOUND;
+			case NOT_MENU_OWNER -> HttpStatus.FORBIDDEN;
+			case MENU_SOLD_OUT -> HttpStatus.BAD_REQUEST;
+		};
+		return ResponseEntity
+			.status(status)
+			.body(ApiResponse.fail(e.getErrorMessage()));
+	}
+
+	@ExceptionHandler(CartException.class)
+	public ResponseEntity<ApiResponse<?>> handleCartException(CartException e) {
+		HttpStatus status = switch (e.getCartErrorCode()) {
+			case DIFFERENT_STORE -> HttpStatus.BAD_REQUEST;
 		};
 		return ResponseEntity
 			.status(status)

--- a/src/main/java/com/delivery/menu/domain/Menu.java
+++ b/src/main/java/com/delivery/menu/domain/Menu.java
@@ -57,6 +57,10 @@ public class Menu {
 		this.description = description;
 	}
 
+	public Long getStoreId() {
+		return store.getStore_id();
+	}
+
 	public boolean validateOwner(String email) {
 		return this.store.getOwner().getEmail().equals(email);
 	}

--- a/src/main/java/com/delivery/menu/exception/MenuErrorCode.java
+++ b/src/main/java/com/delivery/menu/exception/MenuErrorCode.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MenuErrorCode implements ErrorCode {
 	MENU_NOT_FOUND("존재하지 않는 메뉴입니다."),
-	NOT_MENU_OWNER("해당 가게의 사장님만 메뉴를 등록할 수 있습니다.");
+	NOT_MENU_OWNER("해당 가게의 사장님만 메뉴를 등록할 수 있습니다."),
+	MENU_SOLD_OUT("품절된 메뉴입니다.");
 
 	private final String message;
 }

--- a/src/main/java/com/delivery/menu/repository/MenuRepository.java
+++ b/src/main/java/com/delivery/menu/repository/MenuRepository.java
@@ -20,4 +20,7 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
 
     @Query("SELECT m FROM Menu m JOIN FETCH m.store s JOIN FETCH s.owner WHERE m.menu_id = :menuId AND m.store.store_id = :storeId")
     Optional<Menu> findByIdAndStoreIdWithOwner(@Param("menuId") Long menuId, @Param("storeId") Long storeId);
+
+    @Query("SELECT m FROM Menu m JOIN FETCH m.store WHERE m.menu_id = :menuId")
+    Optional<Menu> findByIdWithStore(@Param("menuId") Long menuId);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #9 

## 📝작업 내용
  - 인증된 회원의 장바구니 조회, 없으면 신규 생성
  - 동일 메뉴가 이미 담겨있을 경우 수량 합산, 없으면 요청 수량으로 신규 추가
  - 담기 성공 시 201 Created 및 장바구니 정보 반환
  