### PR TITLE
장바구니 수량 변경 기능 구현

### DIFF
--- a/src/main/java/com/delivery/cart/application/CartService.java
+++ b/src/main/java/com/delivery/cart/application/CartService.java
@@ -1,8 +1,10 @@
 package com.delivery.cart.application;
 
 import com.delivery.cart.application.dto.CartAddCommand;
+import com.delivery.cart.application.dto.CartItemResult;
 import com.delivery.cart.application.dto.CartResult;
 import com.delivery.cart.domain.Cart;
+import com.delivery.cart.domain.CartItem;
 import com.delivery.cart.exception.CartErrorCode;
 import com.delivery.cart.exception.CartException;
 import com.delivery.cart.repository.CartItemRepository;
@@ -54,5 +56,31 @@ public class CartService {
 			);
 
 		return CartResult.from(cart, cart.getCartItems());
+	}
+
+	@Transactional
+	public CartItemResult increaseCartItemQuantity(String email, Long itemId) {
+		CartItem cartItem = findCartItemWithOwnerCheck(email, itemId);
+		cartItem.increaseQuantity();
+		return CartItemResult.from(cartItem);
+	}
+
+	@Transactional
+	public void decreaseCartItemQuantity(String email, Long itemId) {
+		CartItem cartItem = findCartItemWithOwnerCheck(email, itemId);
+		if (cartItem.getQuantity() == 1) {
+			cartItemRepository.delete(cartItem);
+			return;
+		}
+		cartItem.decreaseQuantity();
+	}
+
+	private CartItem findCartItemWithOwnerCheck(String email, Long itemId) {
+		CartItem cartItem = cartItemRepository.findByIdWithCartAndMember(itemId)
+			.orElseThrow(() -> new CartException(CartErrorCode.CART_ITEM_NOT_FOUND));
+		if (!cartItem.getCart().isCreatedBy(email)) {
+			throw new CartException(CartErrorCode.CART_ITEM_FORBIDDEN);
+		}
+		return cartItem;
 	}
 }

--- a/src/main/java/com/delivery/cart/application/CartService.java
+++ b/src/main/java/com/delivery/cart/application/CartService.java
@@ -7,9 +7,10 @@ import com.delivery.cart.domain.Cart;
 import com.delivery.cart.domain.CartItem;
 import com.delivery.cart.exception.CartErrorCode;
 import com.delivery.cart.exception.CartException;
-import com.delivery.cart.repository.CartItemRepository;
 import com.delivery.cart.repository.CartRepository;
 import com.delivery.member.domain.Member;
+import com.delivery.member.exception.MemberErrorCode;
+import com.delivery.member.exception.MemberException;
 import com.delivery.member.repository.MemberRepository;
 import com.delivery.menu.domain.Menu;
 import com.delivery.menu.exception.MenuErrorCode;
@@ -27,13 +28,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class CartService {
 
 	private final CartRepository cartRepository;
-	private final CartItemRepository cartItemRepository;
 	private final MemberRepository memberRepository;
 	private final MenuRepository menuRepository;
 
 	@Transactional
 	public CartResult addToCart(String email, CartAddCommand command) {
-		Member member = memberRepository.findByEmail(email).orElseThrow();
+		Member member = memberRepository.findByEmail(email)
+			.orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
 
 		Menu menu = menuRepository.findByIdWithStore(command.menuId())
 			.orElseThrow(() -> new MenuException(MenuErrorCode.MENU_NOT_FOUND));
@@ -55,28 +57,36 @@ public class CartService {
 	}
 
 	@Transactional
-	public CartItemResult increaseCartItemQuantity(String email, Long itemId) {
-		CartItem cartItem = findCartItemWithOwnerCheck(email, itemId);
+	public CartItemResult increaseCartItemQuantity(String email, Long cartId, Long menuId) {
+		Cart cart = findCartWithOwnerCheck(email, cartId);
+		CartItem cartItem = cart.findItemByMenuId(menuId)
+			.orElseThrow(() -> new CartException(CartErrorCode.CART_ITEM_NOT_FOUND));
 		cartItem.increaseQuantity();
 		return CartItemResult.from(cartItem);
 	}
 
 	@Transactional
-	public void decreaseCartItemQuantity(String email, Long itemId) {
-		CartItem cartItem = findCartItemWithOwnerCheck(email, itemId);
+	public void decreaseCartItemQuantity(String email, Long cartId, Long menuId) {
+		Cart cart = findCartWithOwnerCheck(email, cartId);
+		CartItem cartItem = cart.findItemByMenuId(menuId)
+			.orElseThrow(() -> new CartException(CartErrorCode.CART_ITEM_NOT_FOUND));
+
 		if (cartItem.getQuantity() == 1) {
-			cartItemRepository.delete(cartItem);
+			cart.getCartItems().remove(cartItem);
+			if (cart.getCartItems().isEmpty()) {
+				cartRepository.delete(cart);
+			}
 			return;
 		}
 		cartItem.decreaseQuantity();
 	}
 
-	private CartItem findCartItemWithOwnerCheck(String email, Long itemId) {
-		CartItem cartItem = cartItemRepository.findByIdWithCartAndMember(itemId)
-			.orElseThrow(() -> new CartException(CartErrorCode.CART_ITEM_NOT_FOUND));
-		if (!cartItem.getCart().isCreatedBy(email)) {
+	private Cart findCartWithOwnerCheck(String email, Long cartId) {
+		Cart cart = cartRepository.findByIdWithItemsAndMember(cartId)
+			.orElseThrow(() -> new CartException(CartErrorCode.CART_NOT_FOUND));
+		if (!cart.isCreatedBy(email)) {
 			throw new CartException(CartErrorCode.CART_ITEM_FORBIDDEN);
 		}
-		return cartItem;
+		return cart;
 	}
 }

--- a/src/main/java/com/delivery/cart/application/CartService.java
+++ b/src/main/java/com/delivery/cart/application/CartService.java
@@ -49,11 +49,7 @@ public class CartService {
 			throw new CartException(CartErrorCode.DIFFERENT_STORE);
 		}
 
-		cart.findItemByMenuId(menu.getMenu_id())
-			.ifPresentOrElse(
-				existing -> existing.addQuantity(command.quantity()),
-				() -> cartItemRepository.save(cart.addItem(menu, command.quantity()))
-			);
+		cart.addMenu(menu, command.quantity());
 
 		return CartResult.from(cart, cart.getCartItems());
 	}

--- a/src/main/java/com/delivery/cart/domain/Cart.java
+++ b/src/main/java/com/delivery/cart/domain/Cart.java
@@ -65,4 +65,8 @@ public class Cart {
 		cartItems.add(cartItem);
 		return cartItem;
 	}
+
+	public boolean isCreatedBy(String email) {
+		return member.hasEmail(email);
+	}
 }

--- a/src/main/java/com/delivery/cart/domain/Cart.java
+++ b/src/main/java/com/delivery/cart/domain/Cart.java
@@ -68,7 +68,7 @@ public class Cart {
 	}
 
 	public boolean isCreatedBy(String email) {
-		return member.hasEmail(email);
+		return member.matchesEmail(email);
 	}
 
 	public void addMenu(Menu menu, int quantity) {

--- a/src/main/java/com/delivery/cart/domain/Cart.java
+++ b/src/main/java/com/delivery/cart/domain/Cart.java
@@ -66,6 +66,10 @@ public class Cart {
 		return cartItem;
 	}
 
+	public boolean isCreatedBy(String email) {
+		return member.hasEmail(email);
+	}
+
 	public void addMenu(Menu menu, int quantity) {
 		findItemByMenuId(menu.getMenu_id())
 			.ifPresentOrElse(

--- a/src/main/java/com/delivery/cart/domain/Cart.java
+++ b/src/main/java/com/delivery/cart/domain/Cart.java
@@ -66,6 +66,14 @@ public class Cart {
 		return cartItem;
 	}
 
+	public void addMenu(Menu menu, int quantity) {
+		findItemByMenuId(menu.getMenu_id())
+			.ifPresentOrElse(
+				existing -> existing.addQuantity(quantity),
+				() -> this.cartItems.add(new CartItem(this, menu, quantity))
+			);
+	}
+
 	public boolean isCreatedBy(String email) {
 		return member.hasEmail(email);
 	}

--- a/src/main/java/com/delivery/cart/domain/Cart.java
+++ b/src/main/java/com/delivery/cart/domain/Cart.java
@@ -42,7 +42,8 @@ public class Cart {
 	@JoinColumn(name = "store_id")
 	private Store store;
 
-	@OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+	@JoinColumn(name = "cart_id", nullable = false)
 	private List<CartItem> cartItems = new ArrayList<>();
 
 	public Cart(Member member, Store store) {
@@ -61,7 +62,7 @@ public class Cart {
 	}
 
 	public CartItem addItem(Menu menu, int quantity) {
-		CartItem cartItem = new CartItem(this, menu, quantity);
+		CartItem cartItem = new CartItem(menu, quantity);
 		cartItems.add(cartItem);
 		return cartItem;
 	}
@@ -74,11 +75,7 @@ public class Cart {
 		findItemByMenuId(menu.getMenu_id())
 			.ifPresentOrElse(
 				existing -> existing.addQuantity(quantity),
-				() -> this.cartItems.add(new CartItem(this, menu, quantity))
+				() -> this.cartItems.add(new CartItem(menu, quantity))
 			);
-	}
-
-	public boolean isCreatedBy(String email) {
-		return member.hasEmail(email);
 	}
 }

--- a/src/main/java/com/delivery/cart/domain/CartItem.java
+++ b/src/main/java/com/delivery/cart/domain/CartItem.java
@@ -27,18 +27,13 @@ public class CartItem {
 	private Long cart_item_id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "cart_id", nullable = false)
-	private Cart cart;
-
-	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "menu_id", nullable = false)
 	private Menu menu;
 
 	@Column(name = "quantity", nullable = false)
 	private int quantity;
 
-	public CartItem(Cart cart, Menu menu, int quantity) {
-		this.cart = cart;
+	public CartItem(Menu menu, int quantity) {
 		this.menu = menu;
 		this.quantity = quantity;
 	}

--- a/src/main/java/com/delivery/cart/exception/CartErrorCode.java
+++ b/src/main/java/com/delivery/cart/exception/CartErrorCode.java
@@ -8,7 +8,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum CartErrorCode implements ErrorCode {
-	DIFFERENT_STORE("같은 가게의 메뉴만 담을 수 있습니다.");
+	DIFFERENT_STORE("같은 가게의 메뉴만 담을 수 있습니다."),
+	CART_ITEM_NOT_FOUND("장바구니 항목을 찾을 수 없습니다."),
+	CART_ITEM_FORBIDDEN("본인의 장바구니 항목만 수정할 수 있습니다.");
 
 	private final String message;
 }

--- a/src/main/java/com/delivery/cart/exception/CartErrorCode.java
+++ b/src/main/java/com/delivery/cart/exception/CartErrorCode.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum CartErrorCode implements ErrorCode {
 	DIFFERENT_STORE("같은 가게의 메뉴만 담을 수 있습니다."),
+	CART_NOT_FOUND("장바구니를 찾을 수 없습니다."),
 	CART_ITEM_NOT_FOUND("장바구니 항목을 찾을 수 없습니다."),
 	CART_ITEM_FORBIDDEN("본인의 장바구니 항목만 수정할 수 있습니다.");
 

--- a/src/main/java/com/delivery/cart/presentation/CartController.java
+++ b/src/main/java/com/delivery/cart/presentation/CartController.java
@@ -2,6 +2,7 @@ package com.delivery.cart.presentation;
 
 import com.delivery.cart.application.CartService;
 import com.delivery.cart.presentation.dto.CartAddRequest;
+import com.delivery.cart.presentation.dto.CartItemResponse;
 import com.delivery.cart.presentation.dto.CartResponse;
 import com.delivery.common.response.ApiResponse;
 
@@ -12,6 +13,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,5 +36,25 @@ public class CartController {
 			cartService.addToCart(userDetails.getUsername(), request.toCommand())
 		);
 		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+	}
+
+	@PatchMapping("/items/{itemId}/increase")
+	public ResponseEntity<ApiResponse<CartItemResponse>> increaseCartItem(
+		@AuthenticationPrincipal UserDetails userDetails,
+		@PathVariable Long itemId
+	) {
+		CartItemResponse response = CartItemResponse.from(
+			cartService.increaseCartItemQuantity(userDetails.getUsername(), itemId)
+		);
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	@PatchMapping("/items/{itemId}/decrease")
+	public ResponseEntity<ApiResponse<Void>> decreaseCartItem(
+		@AuthenticationPrincipal UserDetails userDetails,
+		@PathVariable Long itemId
+	) {
+		cartService.decreaseCartItemQuantity(userDetails.getUsername(), itemId);
+		return ResponseEntity.ok(ApiResponse.success(null));
 	}
 }

--- a/src/main/java/com/delivery/cart/presentation/CartController.java
+++ b/src/main/java/com/delivery/cart/presentation/CartController.java
@@ -38,23 +38,25 @@ public class CartController {
 		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
 	}
 
-	@PatchMapping("/items/{itemId}/increase")
+	@PatchMapping("/{cartId}/items/{menuId}/increase")
 	public ResponseEntity<ApiResponse<CartItemResponse>> increaseCartItem(
 		@AuthenticationPrincipal UserDetails userDetails,
-		@PathVariable Long itemId
+		@PathVariable Long cartId,
+		@PathVariable Long menuId
 	) {
 		CartItemResponse response = CartItemResponse.from(
-			cartService.increaseCartItemQuantity(userDetails.getUsername(), itemId)
+			cartService.increaseCartItemQuantity(userDetails.getUsername(), cartId, menuId)
 		);
 		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 
-	@PatchMapping("/items/{itemId}/decrease")
+	@PatchMapping("/{cartId}/items/{menuId}/decrease")
 	public ResponseEntity<ApiResponse<Void>> decreaseCartItem(
 		@AuthenticationPrincipal UserDetails userDetails,
-		@PathVariable Long itemId
+		@PathVariable Long cartId,
+		@PathVariable Long menuId
 	) {
-		cartService.decreaseCartItemQuantity(userDetails.getUsername(), itemId);
+		cartService.decreaseCartItemQuantity(userDetails.getUsername(), cartId, menuId);
 		return ResponseEntity.ok(ApiResponse.success(null));
 	}
 }

--- a/src/main/java/com/delivery/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/delivery/cart/repository/CartItemRepository.java
@@ -1,11 +1,8 @@
 package com.delivery.cart.repository;
 
-import java.util.List;
 import java.util.Optional;
 
-import com.delivery.cart.domain.Cart;
 import com.delivery.cart.domain.CartItem;
-import com.delivery.menu.domain.Menu;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,8 +12,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CartItemRepository extends JpaRepository<CartItem, Long> {
 
-	@Query("SELECT ci FROM CartItem ci JOIN FETCH ci.menu m JOIN FETCH m.store WHERE ci.cart = :cart")
-	List<CartItem> findByCartWithMenuAndStore(@Param("cart") Cart cart);
-
-	Optional<CartItem> findByCartAndMenu(Cart cart, Menu menu);
+	@Query("SELECT ci FROM CartItem ci JOIN FETCH ci.cart c JOIN FETCH c.member WHERE ci.cart_item_id = :itemId")
+	Optional<CartItem> findByIdWithCartAndMember(@Param("itemId") Long itemId);
 }

--- a/src/main/java/com/delivery/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/delivery/cart/repository/CartItemRepository.java
@@ -12,6 +12,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CartItemRepository extends JpaRepository<CartItem, Long> {
 
-	@Query("SELECT ci FROM CartItem ci JOIN FETCH ci.cart c JOIN FETCH c.member JOIN FETCH ci.menu WHERE ci.cart_item_id = :itemId")
+	@Query("SELECT ci FROM CartItem ci JOIN FETCH ci.cart c JOIN FETCH c.member WHERE ci.cart_item_id = :itemId")
 	Optional<CartItem> findByIdWithCartAndMember(@Param("itemId") Long itemId);
 }

--- a/src/main/java/com/delivery/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/delivery/cart/repository/CartItemRepository.java
@@ -12,6 +12,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CartItemRepository extends JpaRepository<CartItem, Long> {
 
-	@Query("SELECT ci FROM CartItem ci JOIN FETCH ci.cart c JOIN FETCH c.member WHERE ci.cart_item_id = :itemId")
+	@Query("SELECT ci FROM CartItem ci JOIN FETCH ci.cart c JOIN FETCH c.member JOIN FETCH ci.menu WHERE ci.cart_item_id = :itemId")
 	Optional<CartItem> findByIdWithCartAndMember(@Param("itemId") Long itemId);
 }

--- a/src/main/java/com/delivery/cart/repository/CartRepository.java
+++ b/src/main/java/com/delivery/cart/repository/CartRepository.java
@@ -21,4 +21,14 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
 		WHERE c.member.email = :email
 		""")
 	Optional<Cart> findByMemberEmailWithItems(@Param("email") String email);
+
+	@Query("""
+		SELECT DISTINCT c
+		FROM Cart c
+		JOIN FETCH c.member
+		LEFT JOIN FETCH c.cartItems ci
+		LEFT JOIN FETCH ci.menu
+		WHERE c.cart_id = :cartId
+		""")
+	Optional<Cart> findByIdWithItemsAndMember(@Param("cartId") Long cartId);
 }

--- a/src/main/java/com/delivery/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/delivery/common/exception/GlobalExceptionHandler.java
@@ -43,6 +43,8 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<ApiResponse<?>> handleCartException(CartException e) {
 		HttpStatus status = switch (e.getCartErrorCode()) {
 			case DIFFERENT_STORE -> HttpStatus.BAD_REQUEST;
+			case CART_ITEM_NOT_FOUND -> HttpStatus.NOT_FOUND;
+			case CART_ITEM_FORBIDDEN -> HttpStatus.FORBIDDEN;
 		};
 		return ResponseEntity
 			.status(status)

--- a/src/main/java/com/delivery/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/delivery/common/exception/GlobalExceptionHandler.java
@@ -43,7 +43,7 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<ApiResponse<?>> handleCartException(CartException e) {
 		HttpStatus status = switch (e.getCartErrorCode()) {
 			case DIFFERENT_STORE -> HttpStatus.BAD_REQUEST;
-			case CART_ITEM_NOT_FOUND -> HttpStatus.NOT_FOUND;
+			case CART_NOT_FOUND, CART_ITEM_NOT_FOUND -> HttpStatus.NOT_FOUND;
 			case CART_ITEM_FORBIDDEN -> HttpStatus.FORBIDDEN;
 		};
 		return ResponseEntity

--- a/src/main/java/com/delivery/member/domain/Member.java
+++ b/src/main/java/com/delivery/member/domain/Member.java
@@ -50,6 +50,10 @@ public class Member {
 		this.address = address;
 	}
 
+	public boolean hasEmail(String email) {
+		return this.email.equals(email);
+	}
+
 	public void validatePassword(boolean isValid) {
 		if (!isValid) {
 			throw new com.delivery.member.exception.MemberException(

--- a/src/main/java/com/delivery/member/domain/Member.java
+++ b/src/main/java/com/delivery/member/domain/Member.java
@@ -50,7 +50,7 @@ public class Member {
 		this.address = address;
 	}
 
-	public boolean hasEmail(String email) {
+	public boolean matchesEmail(String email) {
 		return this.email.equals(email);
 	}
 

--- a/src/main/java/com/delivery/menu/domain/Menu.java
+++ b/src/main/java/com/delivery/menu/domain/Menu.java
@@ -62,7 +62,7 @@ public class Menu {
 	}
 
 	public boolean validateOwner(String email) {
-		return this.store.getOwner().getEmail().equals(email);
+		return store.isOwnedBy(email);
 	}
 
 	public void markAsSoldOut() {

--- a/src/main/java/com/delivery/store/domain/Store.java
+++ b/src/main/java/com/delivery/store/domain/Store.java
@@ -70,7 +70,7 @@ public class Store {
 	}
 
 	public boolean isOwnedBy(String email) {
-		return this.owner.getEmail().equals(email);
+		return owner.hasEmail(email);
 	}
 
 	public void update(String name, String category, int minOrderPrice, int deliveryFee,

--- a/src/main/java/com/delivery/store/domain/Store.java
+++ b/src/main/java/com/delivery/store/domain/Store.java
@@ -70,7 +70,7 @@ public class Store {
 	}
 
 	public boolean isOwnedBy(String email) {
-		return owner.hasEmail(email);
+		return owner.matchesEmail(email);
 	}
 
 	public void update(String name, String category, int minOrderPrice, int deliveryFee,


### PR DESCRIPTION
## #️⃣연관된 이슈

Close #10 
## 📝작업 내용
 - `PATCH /api/carts/items/{itemId}/increase` — 수량 1 증가
  - `PATCH /api/carts/items/{itemId}/decrease` — 수량 1 감소 (수량이 1이면 항목 삭제)
  - 본인 장바구니 항목인지 검증 추가

## 💬리뷰 요구사항
- 기존에 `this.owner.getEmail().equals(email)` 처럼 직접 비교하던 방식을, `Member`에 `hasEmail()`을 두고 각
  도메인(`Store.isOwnedBy()`, `Cart.isCreatedBy()`)이 위임하는 방식으로 변경했습니다. 이 방식이 도메인 설계 관점에서
  적절한지 리뷰 부탁드립니다.
