### PR TITLE
 feat: 가게 주인의 주문 상태 단계적 진행 기능 구현

### DIFF
--- a/src/main/java/com/delivery/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/delivery/common/exception/GlobalExceptionHandler.java
@@ -11,6 +11,8 @@ import com.delivery.cart.exception.CartException;
 import com.delivery.common.response.ApiResponse;
 import com.delivery.member.exception.MemberException;
 import com.delivery.menu.exception.MenuException;
+import com.delivery.order.exception.OrderException;
+import com.delivery.store.exception.StoreException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -39,12 +41,35 @@ public class GlobalExceptionHandler {
 			.body(ApiResponse.fail(e.getErrorMessage()));
 	}
 
+	@ExceptionHandler(StoreException.class)
+	public ResponseEntity<ApiResponse<?>> handleStoreException(StoreException e) {
+		HttpStatus status = switch (e.getStoreErrorCode()) {
+			case STORE_NOT_FOUND -> HttpStatus.NOT_FOUND;
+			case NOT_STORE_OWNER -> HttpStatus.FORBIDDEN;
+		};
+		return ResponseEntity
+			.status(status)
+			.body(ApiResponse.fail(e.getErrorMessage()));
+	}
+
 	@ExceptionHandler(CartException.class)
 	public ResponseEntity<ApiResponse<?>> handleCartException(CartException e) {
 		HttpStatus status = switch (e.getCartErrorCode()) {
 			case DIFFERENT_STORE, CART_EMPTY -> HttpStatus.BAD_REQUEST;
 			case CART_NOT_FOUND, CART_ITEM_NOT_FOUND -> HttpStatus.NOT_FOUND;
 			case CART_ITEM_FORBIDDEN -> HttpStatus.FORBIDDEN;
+		};
+		return ResponseEntity
+			.status(status)
+			.body(ApiResponse.fail(e.getErrorMessage()));
+	}
+
+	@ExceptionHandler(OrderException.class)
+	public ResponseEntity<ApiResponse<?>> handleOrderException(OrderException e) {
+		HttpStatus status = switch (e.getOrderErrorCode()) {
+			case ORDER_NOT_FOUND -> HttpStatus.NOT_FOUND;
+			case NOT_ORDER_STORE_OWNER -> HttpStatus.FORBIDDEN;
+			case INVALID_STATUS_TRANSITION -> HttpStatus.BAD_REQUEST;
 		};
 		return ResponseEntity
 			.status(status)

--- a/src/main/java/com/delivery/order/application/OrderService.java
+++ b/src/main/java/com/delivery/order/application/OrderService.java
@@ -4,7 +4,11 @@ import com.delivery.cart.application.CartService;
 import com.delivery.cart.domain.Cart;
 import com.delivery.order.application.dto.OrderResult;
 import com.delivery.order.domain.Order;
+import com.delivery.order.exception.OrderErrorCode;
+import com.delivery.order.exception.OrderException;
 import com.delivery.order.repository.OrderRepository;
+import com.delivery.store.application.StoreService;
+import com.delivery.store.domain.Store;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,6 +22,7 @@ public class OrderService {
 
 	private final OrderRepository orderRepository;
 	private final CartService cartService;
+	private final StoreService storeService;
 
 	@Transactional
 	public OrderResult createOrder(String email) {
@@ -29,5 +34,23 @@ public class OrderService {
 		cartService.clearCart(cart);
 
 		return OrderResult.from(order);
+	}
+
+	@Transactional
+	public OrderResult advanceOrderStatus(String email, Long orderId) {
+		Order order = findOrder(orderId);
+
+		Store store = storeService.findStore(order.storeId());
+		if (!store.isOwnedBy(email)) {
+			throw new OrderException(OrderErrorCode.NOT_ORDER_STORE_OWNER);
+		}
+
+		order.advanceStatus();
+		return OrderResult.from(order);
+	}
+
+	private Order findOrder(Long orderId) {
+		return orderRepository.findById(orderId)
+			.orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/delivery/order/domain/Order.java
+++ b/src/main/java/com/delivery/order/domain/Order.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 import com.delivery.cart.domain.Cart;
 import com.delivery.member.domain.Member;
+import com.delivery.order.exception.OrderErrorCode;
+import com.delivery.order.exception.OrderException;
 import com.delivery.store.domain.Store;
 
 import jakarta.persistence.CascadeType;
@@ -71,5 +73,16 @@ public class Order {
 
 		order.totalPrice = order.orderItems.stream().mapToInt(OrderItem::getSubtotal).sum();
 		return order;
+	}
+
+	public Long storeId() {
+		return store.getStore_id();
+	}
+
+	public void advanceStatus() {
+		if (!this.status.hasNext()) {
+			throw new OrderException(OrderErrorCode.INVALID_STATUS_TRANSITION);
+		}
+		this.status = this.status.next();
 	}
 }

--- a/src/main/java/com/delivery/order/domain/OrderStatus.java
+++ b/src/main/java/com/delivery/order/domain/OrderStatus.java
@@ -1,5 +1,18 @@
 package com.delivery.order.domain;
 
 public enum OrderStatus {
-	PENDING, CONFIRMED, DELIVERED, CANCELLED
+	PENDING, ACCEPTED, DELIVERING, DONE;
+
+	public boolean hasNext() {
+		return this != DONE;
+	}
+
+	public OrderStatus next() {
+		return switch (this) {
+			case PENDING -> ACCEPTED;
+			case ACCEPTED -> DELIVERING;
+			case DELIVERING -> DONE;
+			case DONE -> throw new IllegalStateException("마지막 상태입니다.");
+		};
+	}
 }

--- a/src/main/java/com/delivery/order/exception/OrderErrorCode.java
+++ b/src/main/java/com/delivery/order/exception/OrderErrorCode.java
@@ -1,0 +1,16 @@
+package com.delivery.order.exception;
+
+import com.delivery.common.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderErrorCode implements ErrorCode {
+	ORDER_NOT_FOUND("존재하지 않는 주문입니다."),
+	NOT_ORDER_STORE_OWNER("가게 사장님만 주문 상태를 변경할 수 있습니다."),
+	INVALID_STATUS_TRANSITION("유효하지 않은 주문 상태 전이입니다.");
+
+	private final String message;
+}

--- a/src/main/java/com/delivery/order/exception/OrderException.java
+++ b/src/main/java/com/delivery/order/exception/OrderException.java
@@ -1,0 +1,16 @@
+package com.delivery.order.exception;
+
+import com.delivery.common.exception.CustomException;
+
+public class OrderException extends CustomException {
+	private final OrderErrorCode errorCode;
+
+	public OrderException(OrderErrorCode errorCode) {
+		super(errorCode);
+		this.errorCode = errorCode;
+	}
+
+	public OrderErrorCode getOrderErrorCode() {
+		return errorCode;
+	}
+}

--- a/src/main/java/com/delivery/order/presentation/OrderController.java
+++ b/src/main/java/com/delivery/order/presentation/OrderController.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,5 +31,16 @@ public class OrderController {
 			orderService.createOrder(userDetails.getUsername())
 		);
 		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+	}
+
+	@PatchMapping("/{orderId}/status/next")
+	public ResponseEntity<ApiResponse<OrderResponse>> advanceOrderStatus(
+		@AuthenticationPrincipal UserDetails userDetails,
+		@PathVariable Long orderId
+	) {
+		OrderResponse response = OrderResponse.from(
+			orderService.advanceOrderStatus(userDetails.getUsername(), orderId)
+		);
+		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

Closes #14 

## 📝작업 내용
  가게 주인이 주문 상태를 단계적으로 진행할 수 있는 기능을 구현했습니다.

  **상태 전이 흐름**
  `PENDING` → `ACCEPTED` → `DELIVERING` → `DONE`

  **구현 내용**
  - `PATCH /api/orders/{orderId}/status/next` 엔드포인트 추가
  - 요청 body 없이 현재 상태에서 다음 단계로만 이동하는 단방향 구조
  - 가게 주인 본인 주문만 처리 가능 (타인 요청 시 403)
  - 존재하지 않는 주문 요청 시 404, DONE 상태에서 추가 요청 시 400

  **소유자 검증**
  `OrderRepository`에 별도 쿼리를 추가하지 않고 기존 `StoreService.findStore()`를 재사용하여 store + owner를 JOIN FETCH로 한 번에 조회

